### PR TITLE
Add test for invalid check digits.

### DIFF
--- a/lei-validator.js
+++ b/lei-validator.js
@@ -36,6 +36,11 @@ function validateLEI(leiCode) {
 
     code = code.toUpperCase();
 
+    if (code.match(/(00|01|99)$/)) {
+        return false;
+    }
+    
+
     var computedCode = '';
 
     for (var i = 0; i < 20; i++) {


### PR DESCRIPTION
The final stage of the checksum calculation is to subtract the remainder
of a division by 97 (0-96) from 98.  Valid values are thus 02 to 98.  An
LEI which ends in 00,01 or 99 is thus not valid even if the remainder of
dividing by 97 is 1.

This is discussed in "Guidelines for Computing and Validating Check Digits for LEIs" published by ISO/TC 68 on 7th July 2016.